### PR TITLE
SLING-8197 - Migrated TenantProviderImpl to OSGi R6 and moved version…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     </parent>
 
     <artifactId>org.apache.sling.tenant</artifactId>
-    <version>1.1.2</version>
+    <version>1.1.3-SNAPSHOT</version>
     <packaging>bundle</packaging>
 
     <name>Apache Sling Tenant</name>
@@ -67,11 +67,6 @@
     
     <dependencies>
         <dependency>
-            <groupId>org.apache.felix</groupId>
-            <artifactId>org.apache.felix.scr.annotations</artifactId>
-            <version>1.11.0</version>
-        </dependency>
-        <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.api</artifactId>
             <version>2.5.0</version>
@@ -81,6 +76,16 @@
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.commons.osgi</artifactId>
             <version>2.1.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.service.component.annotations</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.service.metatype.annotations</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/src/test/java/org/apache/sling/tenant/internal/TenantProviderImplTest.java
+++ b/src/test/java/org/apache/sling/tenant/internal/TenantProviderImplTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.sling.tenant.internal;
 
+import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -41,7 +42,21 @@ public class TenantProviderImplTest {
         Mockito.when(rrf.getServiceResourceResolver(
                 Mockito.anyMapOf(String.class, Object.class))).thenReturn(rr);
         set(provider, "factory", rrf);
-        provider.activate(context, new HashMap<String, Object>());
+        TenantProviderImpl.Configuration configuration = new TenantProviderImpl.Configuration() {
+            @Override
+            public Class<? extends Annotation> annotationType() {
+                return null;
+            }
+            @Override
+            public String tenant_root() {
+                return "/etc/tenants";
+            }
+            @Override
+            public String[] tenant_path_matcher() {
+                return new String[] {};
+            }
+        };
+        provider.activate(context, configuration);
         Iterator<Tenant> tenants = provider.getTenants();
         TestCase.assertNotNull(tenants);
         TestCase.assertFalse(tenants.hasNext());


### PR DESCRIPTION
… to 1.1.3

This will re-introduce the OSGi services of Tenant Provider / Manager which was not created becuase the OSGi definition was still made with Felix SCR Annotations