### PR TITLE
binding change to method level

### DIFF
--- a/src/main/java/org/apache/sling/tenant/internal/TenantProviderImpl.java
+++ b/src/main/java/org/apache/sling/tenant/internal/TenantProviderImpl.java
@@ -71,19 +71,7 @@ import org.slf4j.LoggerFactory;
             Constants.SERVICE_VENDOR + "=The Apache Software Foundation",
             Constants.SERVICE_DESCRIPTION + "=Apache Sling Tenant Provider"
     },
-    immediate = true,
-    reference = {
-        @Reference(
-            name = "tenantSetup",
-            service = TenantCustomizer.class,
-            cardinality = ReferenceCardinality.MULTIPLE,
-            policy = ReferencePolicy.DYNAMIC),
-        @Reference(
-                name = "hook",
-                service = TenantManagerHook.class,
-                cardinality = ReferenceCardinality.MULTIPLE,
-                policy = ReferencePolicy.DYNAMIC)
-    }
+    immediate = true
 )
 @Designate(ocd = TenantProviderImpl.Configuration.class)
 public class TenantProviderImpl implements TenantProvider, TenantManager {
@@ -151,7 +139,12 @@ public class TenantProviderImpl implements TenantProvider, TenantManager {
         }
     }
 
-    @SuppressWarnings("unused")
+    @Reference(
+            name = "tenantSetup",
+            service = TenantCustomizer.class,
+            cardinality = ReferenceCardinality.MULTIPLE,
+            unbind="unbindTenantSetup",
+            policy = ReferencePolicy.DYNAMIC)
     private synchronized void bindTenantSetup(TenantCustomizer action, ServiceReference<TenantCustomizer> ref) {
         registeredTenantHandlers.put(ref, action);
     }
@@ -165,7 +158,12 @@ public class TenantProviderImpl implements TenantProvider, TenantManager {
         return registeredTenantHandlers.values();
     }
 
-    @SuppressWarnings("unused")
+    @Reference(
+            name = "hook",
+            service = TenantManagerHook.class,
+            cardinality = ReferenceCardinality.MULTIPLE,
+            unbind = "unbindHook",
+            policy = ReferencePolicy.DYNAMIC)
     private synchronized void bindHook(TenantManagerHook action, ServiceReference<TenantCustomizer> ref) {
         registeredHooks.put(ref, action);
     }


### PR DESCRIPTION
In [OSGI documentation](https://docs.osgi.org/javadoc/r6/cmpn/org/osgi/service/component/annotations/Reference.html) , i found that binding of service is possible on method level or field level & not on class level.
In [SCR documentation](https://felix.apache.org/documentation/subprojects/apache-felix-maven-scr-plugin/scr-annotations.html#_reference), it written it should be on class level or field level
Currently it is set on [class level](https://github.com/apache/sling-org-apache-sling-tenant/blob/org.apache.sling.tenant-1.1.4/src/main/java/org/apache/sling/tenant/internal/TenantProviderImpl.java#L73) , on moving binding to method level tenant creation is working.
Any inputs?