### PR TITLE
SLING-12285 adding bind & unbind methods mapping

### DIFF
--- a/src/main/java/org/apache/sling/tenant/internal/TenantProviderImpl.java
+++ b/src/main/java/org/apache/sling/tenant/internal/TenantProviderImpl.java
@@ -77,12 +77,16 @@ import org.slf4j.LoggerFactory;
             name = "tenantSetup",
             service = TenantCustomizer.class,
             cardinality = ReferenceCardinality.MULTIPLE,
-            policy = ReferencePolicy.DYNAMIC),
+            policy = ReferencePolicy.DYNAMIC,
+            bind =  "bindTenantSetup",
+            unbind = "unbindTenantSetup"),
         @Reference(
                 name = "hook",
                 service = TenantManagerHook.class,
                 cardinality = ReferenceCardinality.MULTIPLE,
-                policy = ReferencePolicy.DYNAMIC)
+                policy = ReferencePolicy.DYNAMIC,
+                bind =  "bindHook",
+                unbind = "unbindHook")
     }
 )
 @Designate(ocd = TenantProviderImpl.Configuration.class)


### PR DESCRIPTION
Adding bind & unbind methods mapping in reference annotation.
Currently Binding & Unbinding of methods are not working after moving on OSGI R6 annotation.